### PR TITLE
Don't merge to `branch/24.08`: Upgrade to runtime 25.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.freepascal.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.freepascal.metainfo.xml
@@ -8,6 +8,9 @@
   <summary>A compiler for the closely related programming-language dialects Pascal and Object Pascal</summary>
   <url type="homepage">https://www.freepascal.org/</url>
   <releases>
+    <release version="4.2" date="2025-07-20">
+      <description></description>
+    </release>
     <release version="3.2.2" date="2021-08-05"/>
   </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.freepascal.yml
+++ b/org.freedesktop.Sdk.Extension.freepascal.yml
@@ -34,36 +34,34 @@ modules:
       - make -C fpcsrc packages_smart utils_all PP=`pwd`/fpcsrc/compiler/${PPNAME}
       # install
       - make -C fpcsrc compiler_distinstall rtl_distinstall packages_distinstall utils_distinstall
-        INSTALL_PREFIX=${PREFIX}
-        PP=`pwd`/fpcsrc/compiler/${PPNAME}
-        FPCMAKE=`pwd`/fpcsrc/utils/fpcm/bin/${FLATPAK_ARCH}-linux/fpcmake
+        INSTALL_PREFIX=${PREFIX} PP=`pwd`/fpcsrc/compiler/${PPNAME} FPCMAKE=`pwd`/fpcsrc/utils/fpcm/bin/${FLATPAK_ARCH}-linux/fpcmake
       # make cfg, add lib path, and link ppc
-      -  ${PREFIX}/lib/fpc/${fpcver}/samplecfg ${PREFIX}/lib/fpc/${fpcver} ${PREFIX}/etc
-      -  echo '-Fl/app/lib' >> ${PREFIX}/etc/fpc.cfg
-      -  ln -s ../lib/fpc/${fpcver}/${PPNAME} ${PREFIX}/bin/${PPNAME}
+      - ${PREFIX}/lib/fpc/${fpcver}/samplecfg ${PREFIX}/lib/fpc/${fpcver} ${PREFIX}/etc
+      - echo '-Fl/app/lib' >> ${PREFIX}/etc/fpc.cfg
+      - ln -s ../lib/fpc/${fpcver}/${PPNAME} ${PREFIX}/bin/${PPNAME}
       # fix not found ppcaarch64
-      -  ln -s ppca64 ${PREFIX}/bin/ppcaarch64
+      - ln -s ppca64 ${PREFIX}/bin/ppcaarch64
     sources:
       - type: archive
         only-arches:
           - x86_64
-        url: 'https://downloads.sourceforge.net/project/freepascal/Linux/3.2.2/fpc-3.2.2.x86_64-linux.tar'
+        url: https://downloads.sourceforge.net/project/freepascal/Linux/3.2.2/fpc-3.2.2.x86_64-linux.tar
         sha256: 5adac308a5534b6a76446d8311fc340747cbb7edeaacfe6b651493ff3fe31e83
 
       - type: archive
         only-arches:
           - aarch64
-        url: 'https://downloads.sourceforge.net/project/freepascal/Linux/3.2.2/fpc-3.2.2.aarch64-linux.tar'
+        url: https://downloads.sourceforge.net/project/freepascal/Linux/3.2.2/fpc-3.2.2.aarch64-linux.tar
         sha256: b39470f9b6b5b82f50fc8680a5da37d2834f2129c65c24c5628a80894d565451
 
       - type: archive
-        url: 'https://downloads.sourceforge.net/project/freepascal/Source/3.2.2/fpcbuild-3.2.2.tar.gz'
+        url: https://downloads.sourceforge.net/project/freepascal/Source/3.2.2/fpcbuild-3.2.2.tar.gz
         sha256: 85ef993043bb83f999e2212f1bca766eb71f6f973d362e2290475dbaaf50161f
 
       - type: patch
         options:
-          - '-d'
-          - 'fpcsrc'
+          - -d
+          - fpcsrc
         path: fpc-3.2.0--glibc-2.34.patch
 
   - name: lazarus
@@ -81,17 +79,17 @@ modules:
       - make lazbuild OPT='-gl'
       - touch lazarus startlazarus
       - make install
-      - sed -i -e "s#__LAZARUSDIR__#$LAZARUSDIR/#" -e "s#__FPCSRCDIR__#$FPCDIR/#" -e "s#/usr/bin/fpc#$INSTALL_PREFIX/bin/fpc#"
-        tools/install/linux/environmentoptions.xml
+      - sed -i -e "s#__LAZARUSDIR__#$LAZARUSDIR/#" -e "s#__FPCSRCDIR__#$FPCDIR/#"
+        -e "s#/usr/bin/fpc#$INSTALL_PREFIX/bin/fpc#" tools/install/linux/environmentoptions.xml
       - install -Dm644 -t $LAZARUSDIR tools/install/linux/environmentoptions.xml
     sources:
       - type: archive
-        url: 'https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%203.6/lazarus-3.6-0.tar.gz'
-        sha256: e65b90367f63bf17cb7bf35f5be69c9ef704ca494e91d8c67d072e3373fab085
+        url: https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%204.2/lazarus-4.2-0.tar.gz
+        sha256: 46c746d765d61f4e2ab270fc7407b844f039e96f1cc65eee7e01e9d3abfc327a
         x-checker-data:
           type: anitya
           project-id: 1538
-          url-template: 'https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%20$major.$minor/lazarus-$version-0.tar.gz'
+          url-template: https://sourceforge.net/projects/lazarus/files/Lazarus%20Zip%20_%20GZip/Lazarus%20$major.$minor/lazarus-$version-0.tar.gz
 
   - name: script
     buildsystem: simple
@@ -113,7 +111,8 @@ modules:
           - export FPC_DIR=$FPCDIR
           - export LAZARUSDIR=/usr/lib/sdk/freepascal/share/lazarus
           # "$HOME/.lazarus" is lazarus's default 'primary-config-path'
-          - '[ -e "$HOME/.lazarus/environmentoptions.xml" ] || install -Dm644 $LAZARUSDIR/environmentoptions.xml -t "$HOME/.lazarus"'
+          - '[ -e "$HOME/.lazarus/environmentoptions.xml" ] || install -Dm644 $LAZARUSDIR/environmentoptions.xml
+            -t "$HOME/.lazarus"'
 
       - type: file
         path: org.freedesktop.Sdk.Extension.freepascal.metainfo.xml

--- a/org.freedesktop.Sdk.Extension.freepascal.yml
+++ b/org.freedesktop.Sdk.Extension.freepascal.yml
@@ -1,7 +1,7 @@
 app-id: org.freedesktop.Sdk.Extension.freepascal
-branch: '24.08'
+branch: '25.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 build-extension: true
 separate-locales: false


### PR DESCRIPTION
This would need to be pushed to `branch/25.08`.
I've tested it with [ddrescueview](https://github.com/flathub/net.sourceforge.ddrescueview) and https://github.com/flathub/shared-modules/pull/414.

I've also bumped Lazarus to 4.2 which adds rather buggy gtk3 support.